### PR TITLE
Added gyro bias capability

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu_sensor.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_imu_sensor.h
@@ -113,6 +113,8 @@ namespace gazebo
     double gaussian_noise_magnetometer;
     /// \brief Offset parameter, position part is unused.
     ignition::math::Pose3d offset;
+    /// \brief Optional offset parameter for gyro to simulate miscalibration/bias
+    ignition::math::Vector3d gyro_offset;
     /// \brief Optional delay in seconds before sending data (and before the first dropout delay)
     double delayed_start_min_s{0.0};
     double delayed_start_max_s{0.0};

--- a/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
+++ b/gazebo_plugins/src/gazebo_ros_imu_sensor.cpp
@@ -120,7 +120,7 @@ void gazebo::GazeboRosImuSensor::UpdateChild(const gazebo::common::UpdateInfo &/
 #endif
     orientation = offset.Rot()*sensor->Orientation(); //applying offsets to the orientation measurement
     accelerometer_data = sensor->LinearAcceleration();
-    gyroscope_data = sensor->AngularVelocity();
+    gyroscope_data = sensor->AngularVelocity() + gyro_offset;
 
     //Guassian noise is applied to all measurements
     imu_msg.orientation.x = orientation.X() + GuassianKernel(0,gaussian_noise_magnetometer);
@@ -357,6 +357,18 @@ bool gazebo::GazeboRosImuSensor::LoadParameters()
   {
     offset.Rot() = ignition::math::Quaterniond::Identity;
     ROS_WARN_STREAM("missing <rpyOffset>, set to default: " << offset.Rot().Roll() << ' ' << offset.Rot().Pitch() << ' ' << offset.Rot().Yaw());
+  }
+
+  //GYRO OFFSET
+  if (sdf->HasElement("gyroOffset"))
+  {
+    gyro_offset =  sdf->Get<ignition::math::Vector3d>("gyroOffset");
+    ROS_INFO_STREAM("<gyroOffset> set to: " << gyro_offset[0] << ' ' << gyro_offset[1] << ' ' << gyro_offset[2]);
+  }
+  else
+  {
+    gyro_offset = ignition::math::Vector3d(0, 0, 0);
+    ROS_WARN_STREAM("missing <gyroOffset>, set to default: " << gyro_offset[0] << ' ' << gyro_offset[1] << ' ' << gyro_offset[2]);
   }
 
   // DELAYED_START_MIN_S


### PR DESCRIPTION
# Added Gyro Bias Capability

Author: @chacalnoir 

Changes:
- Added the capability to define a gyro bias offset on all 3 axes to simulate a mis-calibration.

Tests
[] Tested in simulation against our vehicle.